### PR TITLE
Hide cat entries from the TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ git clone --recursive https://github.com/thegetty/ancient-glass.git
 
 2. Run `quire build`
 
-3. In the `_site/pdf.html` file, find `<section class="quire-page" data-footer-page-title="A. Vessels" data-footer-section-title="Catalogue" id="page-catalogue-a-vessels">` and right before it, add `<div class="catalogue-entries-wrapper">`. And then find `<section class="quire-page" data-footer-page-title="Appendix 1" id="page-appendix-1">` and right before it, add `</div>`. (This creates a new element that wraps all of the catalogue entry pages into one group so that they can flow together in 2-columns.)
+3. In the `_site/pdf.html` file, find `<section class="quire-page" data-footer-page-title="A. Vessels" data-footer-section-title="Catalogue" id="page-catalogue-a-vessels">` and right before it, add `<div class="catalogue-entries-wrapper">`. And then find `<section class="quire-page quire-essay" data-footer-page-title="Appendix 1. Non-invasive Analytical Strategies" id="page-appendix-1">` and right before it, add `</div>`. (This creates a new element that wraps all of the catalogue entry pages into one group so that they can flow together in 2-columns.) 
 
 3. If the PDF will be sent to digital printer, run the following command to ensure color profiles are correct:
 
@@ -77,6 +77,9 @@ TK
 **_includes/components/table-of-contents/item/list.js**
 **_includes/components/table-of-contents/item/grid.js**
 Don't render menu or TOC links if page is `landing: false`
+
+**_includes/components/table-of-contents/item/list.js**
+Add a `data-layout` attribute to facilitate CSS hiding of cat. entries
 
 **_layouts/cover.liquid**
 Added publication.cover_title in place of the default title

--- a/_includes/components/table-of-contents/item/list.js
+++ b/_includes/components/table-of-contents/item/list.js
@@ -1,6 +1,7 @@
 //
 // CUSTOMIZED FILE
 // Don't render TOC link if page is `landing: false`
+// Add a `data-layout` attribute to facilitate CSS hiding of cat. entries
 //
 const { html, oneLine } = require('~lib/common-tags')
 
@@ -76,7 +77,7 @@ module.exports = function (eleventyConfig) {
     }
 
     return html`
-      <li class="${classes.join(' ')}">
+      <li class="${classes.join(' ')}" data-layout="${layout}">
         ${mainElement}
         ${abstractText}
         ${children}

--- a/content/_assets/styles/custom.css
+++ b/content/_assets/styles/custom.css
@@ -99,11 +99,15 @@
   }
 }
 
-/* MENU
+/* MENU & TOC
 ============================================================================= */
 /* Keep nested section links the same size rather than getting smaller and smaller */
 .quire-menu .section-item ol {
   font-size: .875rem;
+}
+/* Hide catalogue entries from */
+.quire-contents-list .page-item[data-layout='entry'] {
+  display: none;
 }
 
 /* OBJECT GRID


### PR DESCRIPTION
Closes issue #31

After a long time trying more complicated solutions, the easiest and most reliable solution turned out to be tagging all the TOC items with their `layout` type, and then hiding all the items with `layout: entry`.  I'll still want GDI to remove the connection between `toc: true | false` and objects on the objects page in core Quire, but for our needs in this project, this solution should work just fine.