### PR TITLE
Allow for custom labels in tombstones

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Add custom def shortcode for glossary pop-ups
 **_plugins/shortcodes/index.js**
 Add custom def shortcode for accession number catalogue links
 
+**_plugins/shortcodes/tombstone.js**
+Allow for optional custom labels with `field` and `label` attributes
+
 **content/_assets/javascript/application/index.js**
 Display only one pop-up at a time
 

--- a/_plugins/shortcodes/tombstone.js
+++ b/_plugins/shortcodes/tombstone.js
@@ -1,3 +1,8 @@
+//
+// CUSTOMIZED FILE
+// Object properties can have a defined `field` and `label` to 
+// allow for custom label naming. Markdown is supported on the labels.
+//
 const { html, oneLine } = require('~lib/common-tags')
 const path = require('path')
 
@@ -14,15 +19,26 @@ module.exports = function(eleventyConfig, { page }) {
     const markdownify = eleventyConfig.getFilter('markdownify')
     const properties = objects.object_display_order
 
-    const tableRow = (object, property) => {
-      if (!object || !property || !object[property]) return ''
+    const tableRow = (object, propField, propLabel) => {
+      if (!object[propField]) return ''
 
       return html`
         <tr>
-          <td>${titleCase(property)}</td>
-          <td>${markdownify(object[property].toString())}</td>
+          <td>${propLabel}</td>
+          <td>${markdownify(object[propField].toString())}</td>
         </tr>
-      `
+      ` 
+    }
+
+    const tableRowGroup = (object) => {
+      let rows = ''
+      for (const prop of properties) {
+        const propField = prop.field ? prop.field : prop
+        const propLabel = prop.label ? markdownify(prop.label) : titleCase(prop)
+
+        rows += tableRow(object, propField, propLabel)
+      }
+      return rows
     }
 
     const objectLink = (object) => object.link
@@ -37,7 +53,7 @@ module.exports = function(eleventyConfig, { page }) {
         <div class="container">
           <table class="table is-fullwidth">
             <tbody>
-              ${properties.map((property) => tableRow(object, property)).join('')}
+              ${tableRowGroup(object)}
             </tbody>
           </table>
           ${objectLink(object)}

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -5,7 +5,8 @@ object_display_order:
   - production_area
   - find_area
   - material
-  - modeling_technique_and_decoration
+  - field: modeling_technique_and_decoration
+    label: Modeling Technique and Decoration
 
 object_filters:
   - culture


### PR DESCRIPTION
Addresses issue #2 and allows tombstone labels to be customized

```yaml
object_display_order:
  - accession_number
  - dimensions
  - date
  - attribution
  - material
  - field: modeling_technique_and_decoration
    label: "Modeling Technique and Decoration"
```