### PR TITLE
Update project team roles

### DIFF
--- a/content/_data/publication.yaml
+++ b/content/_data/publication.yaml
@@ -54,11 +54,13 @@ publisher:
 project_team: 
   - Ruth Evans Lane, *Project Editor*
   - Kerri Cox Sullivan, *Manuscript Editor*
-  - Greg Albers, *Digital Publications Manager*
   - Dani Grossman, *Cover Design*
   - Molly McGeehan, *Production*
   - Danielle Brink, *Image and Rights Acquisition*
-  - Erin Cecele Dunigan, Jenny Park, and Kate Justement, *Digital Assistants*
+  - Greg Albers, *Digital Publications Manager*
+  - Erin Cecele Dunigan, *Digital Project Lead*
+  - Jenny Park, *Digital Production*
+  - Kate Justement, *Digital Assistant*
 
 # ------------------------------------------------------------------------------
 # Contributors


### PR DESCRIPTION
To better reflect the quantity and quality of work done by @Erin-Cecele and @jenpark-getty on this book, this PR proposes an update to their project team roles from *Digital Assistants* to *Digital Project Lead* and *Digital Production* respectively. I've already run this by Ruth, as well as Pubs managers (as there are some department guidelines around this), and all are happy to have these changes made. :)