### PR TITLE
production_area cleaning

### DIFF
--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -12103,7 +12103,7 @@ object_list:
     end_date: "99"
     date_range: [ "15: 100–0 BCE", "16: 0–100 CE" ]
     production_area: "Uncertain"
-    production_area_filter: [ "Uncertain" ]
+    production_area_filter: [ "" ]
     culture: "Roman"
     material: "Translucent light blue and opaque white glass"
     modeling_technique_and_decoration: "Tooled"


### PR DESCRIPTION
Issue #160 

@geealbers just a couple of questions: 

-Cat. 263 has “Northwestern European Roman provinces” that I turned into “Northwestern Europe” (Ruth wasn’t sure which entries had this and suggested a possible combination but didn’t seem entirely sure of this on the spreadsheet--this is the only instance, I think) 

Cat. 533: No suggestion to combine on spreadsheet, but wondering if “Kerch” = “Panticapaeum (Kerch)." This is the only instance of this. 

Cat. 571: labeled as “uncertain”. Leave as-is? None others like this